### PR TITLE
Add check for audioUnit on initialize.

### DIFF
--- a/CustomRTCAudioDevice/AUAudioUnitRTCAudioDevice.swift
+++ b/CustomRTCAudioDevice/AUAudioUnitRTCAudioDevice.swift
@@ -267,7 +267,7 @@ extension AUAudioUnitRTCAudioDevice: RTCAudioDevice {
   }
 
   func initialize(with delegate: RTCAudioDeviceDelegate) -> Bool {
-    guard self.delegate == nil else {
+    guard self.delegate == nil || self.audioUnit == nil else {
       return false
     }
 


### PR DESCRIPTION
Previously, AUAudioUnitRTCAudioDevice would cause React Native apps to crash when they did a "soft restart", which happens when you hit the "Reload" button in the developer tools or download an EAS-style OTA update. I guess the delegate is already defined but the audioUnit still needs to be spun up in this case. This seems to work around the issue but let me know if there's a better way!